### PR TITLE
bugfix(zpp-2029) - [Local Notifications] Apple's red badge counter is not incrementing when more than 1 notifications is sent

### DIFF
--- a/ZappApple/AppDelegateBase.swift
+++ b/ZappApple/AppDelegateBase.swift
@@ -12,6 +12,7 @@ import React
 import UIKit
 import ZappApple
 import ZappCore
+
 public class AppDelegateBase: UIResponder, UIApplicationDelegate, FacadeConnectorProtocol, AppDelegateProtocol {
     public var connectorInstance: FacadeConnector? {
         return rootController?.facadeConnector

--- a/ZappiOS/ZappiOS/AppDelegate+UNUserNotificationCenterDelegate.swift
+++ b/ZappiOS/ZappiOS/AppDelegate+UNUserNotificationCenterDelegate.swift
@@ -27,12 +27,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             NotificationCenter.default.post(name: .kLocalNotificationRecievedNotification,
                                             object: response)
             
-            //update badge number by adding notification badge to application current badge
-            var badgeNumber = UIApplication.shared.applicationIconBadgeNumber
-            if let countToAdd = response.notification.request.content.badge {
-                badgeNumber += Int(truncating: countToAdd)
-                UIApplication.shared.applicationIconBadgeNumber = badgeNumber
-            }
+            updateApplicationBadgeNumber(with: response.notification.request.content)
             
             uiLayerPluginDelegate?.userNotificationCenterDelegate?.userNotificationCenter?(center,
                                                                                            didReceive: response,
@@ -40,6 +35,15 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         } else {
             localNotificationResponse = response
             completionHandler()
+        }
+    }
+    
+    fileprivate func updateApplicationBadgeNumber(with content: UNNotificationContent) {
+        //update badge number by adding notification badge to application current badge
+        var badgeNumber = UIApplication.shared.applicationIconBadgeNumber
+        if let countToAdd = content.badge {
+            badgeNumber += Int(truncating: countToAdd)
+            UIApplication.shared.applicationIconBadgeNumber = badgeNumber
         }
     }
 }

--- a/ZappiOS/ZappiOS/AppDelegate+UNUserNotificationCenterDelegate.swift
+++ b/ZappiOS/ZappiOS/AppDelegate+UNUserNotificationCenterDelegate.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import UserNotifications
+import UIKit
 
 extension AppDelegate: UNUserNotificationCenterDelegate {
     public func userNotificationCenter(_ center: UNUserNotificationCenter,
@@ -22,14 +23,22 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
                                        didReceive response: UNNotificationResponse,
                                        withCompletionHandler completionHandler: @escaping () -> Void) {
         if isApplicationReady {
-            localNotificatioResponse = nil
+            localNotificationResponse = nil
             NotificationCenter.default.post(name: .kLocalNotificationRecievedNotification,
                                             object: response)
+            
+            //update badge number by adding notification badge to application current badge
+            var badgeNumber = UIApplication.shared.applicationIconBadgeNumber
+            if let countToAdd = response.notification.request.content.badge {
+                badgeNumber += Int(truncating: countToAdd)
+                UIApplication.shared.applicationIconBadgeNumber = badgeNumber
+            }
+            
             uiLayerPluginDelegate?.userNotificationCenterDelegate?.userNotificationCenter?(center,
                                                                                            didReceive: response,
                                                                                            withCompletionHandler: completionHandler)
         } else {
-            localNotificatioResponse = response
+            localNotificationResponse = response
             completionHandler()
         }
     }

--- a/ZappiOS/ZappiOS/AppDelegate.swift
+++ b/ZappiOS/ZappiOS/AppDelegate.swift
@@ -16,7 +16,7 @@ import ZappCore
 class AppDelegate: AppDelegateBase {
     var appCenterHandler = MsAppCenterHandler()
 
-    var localNotificatioResponse: UNNotificationResponse?
+    var localNotificationResponse: UNNotificationResponse?
 
     override func application(_ application: UIApplication,
                               didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
@@ -38,9 +38,9 @@ class AppDelegate: AppDelegateBase {
             application(UIApplication.shared,
                         didReceiveRemoteNotification: remoteUserInfo) { _ in }
         }
-        if let localNotificatioResponse = localNotificatioResponse {
+        if let localNotificationResponse = localNotificationResponse {
             userNotificationCenter(UNUserNotificationCenter.current(),
-                                   didReceive: localNotificatioResponse) {
+                                   didReceive: localNotificationResponse) {
                 // do nothing special on completion
             }
         }


### PR DESCRIPTION
Apple's red badge counter is not incrementing when more than 1 notifications is sent

https://applicaster.atlassian.net/browse/ZPP-2029

## Known issues

- _fill in this section with potential issues / limitations the reviewer(s) should know about_

## Affected packages

- [ ] Native tvOS
- [ ] QuickBrick App set up

### Checklist

- [ ] I've provided a readable title for the PR
- [ ] the title of the PR follows the [conventional commits specifications](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#specification)
- [ ] I've provided a detailed description
- [ ] The PR is scoped to a single task/feature
- [ ] I've included relevant tests (if tests are not included please provide the reason why they aren't)

### UI changes

> Check one of the following checkboxes

- [ ] My PR is not introducing a UI change
- [ ] My PR is introducing UI changes and I provided all screenshots in the PR description

#### PR type

> check one of the following type and make sure all related checkboxes are checked.

- [ ] My PR is a part of a new feature or a feature improvement
  - [ ] I've provided a link in the description to the relevant card in the Zapp cycle feature rollout Trello board.
- [ ] My PR is a bug fix
  - [ ] I provided a link in the description to the relevant Jira ticket or provided the following in the PR description:
    - steps to reproduce a bug
    - expected result

### Having problem feeling out the checklist / Conforming to guidelines - explain why and consult Zapp tech lead / Head of product
