### PR TITLE
chore: update CI to use zapptool 3.9.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       PROJECT_NAME: "ZappApple"
       SCRIPTS_FOLDER: "Scripts"
       BUILD_PATH: ~/build_debug
-      ZAPPTOOL_VERSION: "3.9.7"
+      ZAPPTOOL_VERSION: "3.9.8"
       HOMEBREW_NO_AUTO_UPDATE: "1"
 
       #fastlane variables


### PR DESCRIPTION
## Description
This PR updates the repo to use zappTool 3.9.8 in order to support the new QB platforms

## Affected packages

- [x] Native tvOS
- [x] QuickBrick App set up

### Checklist

- [x] I've provided a readable title for the PR
- [x] the title of the PR follows the [conventional commits specifications](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#specification)
- [x] I've provided a detailed description
- [x] The PR is scoped to a single task/feature
- [ ] I've included relevant tests (if tests are not included please provide the reason why they aren't)

### UI changes

> Check one of the following checkboxes

- [ ] My PR is not introducing a UI change
- [ ] My PR is introducing UI changes and I provided all screenshots in the PR description

#### PR type

> check one of the following type and make sure all related checkboxes are checked.

- [ ] My PR is a part of a new feature or a feature improvement
  - [ ] I've provided a link in the description to the relevant card in the Zapp cycle feature rollout Trello board.
- [ ] My PR is a bug fix
  - [ ] I provided a link in the description to the relevant Jira ticket or provided the following in the PR description:
    - steps to reproduce a bug
    - expected result

### Having problem feeling out the checklist / Conforming to guidelines - explain why and consult Zapp tech lead / Head of product
