### PR TITLE
add zapptool flags for new RN build options

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,21 @@ references:
         cd $targetFolder
         if [ "$bundle_identifier" ];
         then
-          "../ZappTool/ZappTool"
+
+          ZAPPTOOL_FLAGS=""
+
+          if [ -z "$react_native_packager_root" ];
+          then;
+            HOST_URL=$react_native_packager_root
+            ZAPPTOOL_FLAGS="${ZAPPTOOL_FLAGS} -rn ${HOST_URL}"
+          fi;
+
+          if [ -z "$skip_bundle_minification" ];
+          then;
+            ZAPPTOOL_FLAGS="${ZAPPTOOL_FLAGS} -sbm"
+          fi;
+
+          "../ZappTool/ZappTool ${ZAPPTOOL_FLAGS}"
         else
           yarn
         fi


### PR DESCRIPTION
## Description

This PR reads the new zapp build flag to enable options for building the react-native bundle

## Affected packages

- [ ] Native tvOS
- [ ] QuickBrick App set up

### Checklist

- [ ] I've provided a readable title for the PR
- [ ] the title of the PR follows the [conventional commits specifications](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#specification)
- [ ] I've provided a detailed description
- [ ] The PR is scoped to a single task/feature
- [ ] I've included relevant tests (if tests are not included please provide the reason why they aren't)

### UI changes

> Check one of the following checkboxes

- [ ] My PR is not introducing a UI change
- [ ] My PR is introducing UI changes and I provided all screenshots in the PR description

#### PR type

> check one of the following type and make sure all related checkboxes are checked.

- [ ] My PR is a part of a new feature or a feature improvement
  - [ ] I've provided a link in the description to the relevant card in the Zapp cycle feature rollout Trello board.
- [ ] My PR is a bug fix
  - [ ] I provided a link in the description to the relevant Jira ticket or provided the following in the PR description:
    - steps to reproduce a bug
    - expected result

### Having problem feeling out the checklist / Conforming to guidelines - explain why and consult Zapp tech lead / Head of product
