### PR TITLE
feat: add qb native dependencies

### DIFF
--- a/Scripts/autolink-react-dependencies.rb
+++ b/Scripts/autolink-react-dependencies.rb
@@ -35,6 +35,6 @@ def use_react_native! (options={})
   pod 'DoubleConversion', :podspec => "#{prefix}/third-party-podspecs/DoubleConversion.podspec"
   pod 'glog', :podspec => "#{prefix}/third-party-podspecs/glog.podspec"
   pod 'Folly', :podspec => "#{prefix}/third-party-podspecs/Folly.podspec"
-  pod 'RNSVG', :path => './node_modules/react-native-svg'
-  pod 'BVLinearGradient', :path => './node_modules/react-native-linear-gradient'
+  pod 'RNSVG', :path => 'node_modules/react-native-svg'
+  pod 'BVLinearGradient', :path => 'node_modules/react-native-linear-gradient'
 end

--- a/Scripts/autolink-react-dependencies.rb
+++ b/Scripts/autolink-react-dependencies.rb
@@ -36,5 +36,5 @@ def use_react_native! (options={})
   pod 'glog', :podspec => "#{prefix}/third-party-podspecs/glog.podspec"
   pod 'Folly', :podspec => "#{prefix}/third-party-podspecs/Folly.podspec"
   pod 'RNSVG', :path => './node_modules/react-native-svg/RNSVG.podspec'
-  pod 'BVLinearGradient', :path => './node_modules/react-native-linear-gradient/BVLinearGradient.podspec'
+  pod 'BVLinearGradient', :path => './node_modules/react-native-linear-gradient'
 end

--- a/Scripts/autolink-react-dependencies.rb
+++ b/Scripts/autolink-react-dependencies.rb
@@ -35,4 +35,6 @@ def use_react_native! (options={})
   pod 'DoubleConversion', :podspec => "#{prefix}/third-party-podspecs/DoubleConversion.podspec"
   pod 'glog', :podspec => "#{prefix}/third-party-podspecs/glog.podspec"
   pod 'Folly', :podspec => "#{prefix}/third-party-podspecs/Folly.podspec"
+  pod 'RNSVG', :path => './node_modules/react-native-svg/RNSVG.podspec'
+  pod 'BVLinearGradient', :path => './node_modules/react-native-linear-gradient/BVLinearGradient.podspec'
 end

--- a/Scripts/autolink-react-dependencies.rb
+++ b/Scripts/autolink-react-dependencies.rb
@@ -35,6 +35,4 @@ def use_react_native! (options={})
   pod 'DoubleConversion', :podspec => "#{prefix}/third-party-podspecs/DoubleConversion.podspec"
   pod 'glog', :podspec => "#{prefix}/third-party-podspecs/glog.podspec"
   pod 'Folly', :podspec => "#{prefix}/third-party-podspecs/Folly.podspec"
-  pod 'RNSVG', :path => 'node_modules/react-native-svg'
-  pod 'BVLinearGradient', :path => 'node_modules/react-native-linear-gradient'
 end

--- a/Scripts/autolink-react-dependencies.rb
+++ b/Scripts/autolink-react-dependencies.rb
@@ -35,6 +35,6 @@ def use_react_native! (options={})
   pod 'DoubleConversion', :podspec => "#{prefix}/third-party-podspecs/DoubleConversion.podspec"
   pod 'glog', :podspec => "#{prefix}/third-party-podspecs/glog.podspec"
   pod 'Folly', :podspec => "#{prefix}/third-party-podspecs/Folly.podspec"
-  pod 'RNSVG', :path => './node_modules/react-native-svg/RNSVG.podspec'
+  pod 'RNSVG', :path => './node_modules/react-native-svg'
   pod 'BVLinearGradient', :path => './node_modules/react-native-linear-gradient'
 end

--- a/ZappTvOS/package.json
+++ b/ZappTvOS/package.json
@@ -30,7 +30,9 @@
     "@react-native-community/cli-platform-ios": "^4.7.0",
     "react": "16.11.0",
     "react-native-tvos": "0.62.2-0",
-    "react-native": "npm:react-native-tvos@0.62.2-0"
+    "react-native": "npm:react-native-tvos@0.62.2-0",
+    "react-native-linear-gradient": "2.5.6",
+    "react-native-svg": "9.13.6"
   },
   "devDependencies": {
     "@applicaster/zapplicaster-cli": "4.0.0"

--- a/ZappTvOS/yarn.lock
+++ b/ZappTvOS/yarn.lock
@@ -2060,6 +2060,11 @@ bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
+boolbase@^1.0.0, boolbase@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+  integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
+
 boom@7.x.x:
   version "7.3.0"
   resolved "https://registry.yarnpkg.com/boom/-/boom-7.3.0.tgz#733a6d956d33b0b1999da3fe6c12996950d017b9"
@@ -2578,6 +2583,29 @@ cryptiles@4.x.x:
   dependencies:
     boom "7.x.x"
 
+css-select@^2.0.2:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-2.1.0.tgz#6a34653356635934a81baca68d0255432105dbef"
+  integrity sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==
+  dependencies:
+    boolbase "^1.0.0"
+    css-what "^3.2.1"
+    domutils "^1.7.0"
+    nth-check "^1.0.2"
+
+css-tree@^1.0.0-alpha.37:
+  version "1.0.0-alpha.39"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.0.0-alpha.39.tgz#2bff3ffe1bb3f776cf7eefd91ee5cba77a149eeb"
+  integrity sha512-7UvkEYgBAHRG9Nt980lYxjsTrCyHFN53ky3wVsDkiMdVqylqRt+Zc+jm5qw7/qyOvN2dHSYtX0e4MbCCExSvnA==
+  dependencies:
+    mdn-data "2.0.6"
+    source-map "^0.6.1"
+
+css-what@^3.2.1:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-3.3.0.tgz#10fec696a9ece2e591ac772d759aacabac38cd39"
+  integrity sha512-pv9JPyatiPaQ6pf4OvD/dbfm0o5LviWmwxNWzblYf/1u9QZd0ihV+PMwy5jdQWQ3349kZmKEx9WXuSka2dM4cg==
+
 dayjs@^1.8.15:
   version "1.8.27"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.8.27.tgz#a8ae63ee990af28c05c430f0e160ae835a0fbbf8"
@@ -2670,10 +2698,36 @@ destroy@~1.0.4:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
 
+dom-serializer@0:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.2.2.tgz#1afb81f533717175d478655debc5e332d9f9bb51"
+  integrity sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==
+  dependencies:
+    domelementtype "^2.0.1"
+    entities "^2.0.0"
+
 dom-walk@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
   integrity sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=
+
+domelementtype@1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
+  integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
+
+domelementtype@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.0.1.tgz#1f8bdfe91f5a78063274e803b4bdcedf6e94f94d"
+  integrity sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==
+
+domutils@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
+  integrity sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==
+  dependencies:
+    dom-serializer "0"
+    domelementtype "1"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -2723,6 +2777,11 @@ end-of-stream@^1.1.0:
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
+
+entities@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.3.tgz#5c487e5742ab93c15abb5da22759b8590ec03b7f"
+  integrity sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==
 
 envinfo@^7.1.0:
   version "7.5.1"
@@ -3973,6 +4032,11 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+mdn-data@2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.6.tgz#852dc60fcaa5daa2e8cf6c9189c440ed3e042978"
+  integrity sha512-rQvjv71olwNHgiTbfPZFkJtjNMciWgswYeciZhtvWLO8bmX3TnhyA62I6sTWOyZssWHJJjY6/KiWwqQsWWsqOA==
+
 mem@^4.0.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/mem/-/mem-4.3.0.tgz#461af497bc4ae09608cdb2e60eefb69bff744178"
@@ -4518,6 +4582,13 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
+nth-check@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.2.tgz#b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"
+  integrity sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==
+  dependencies:
+    boolbase "~1.0.0"
+
 nullthrows@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/nullthrows/-/nullthrows-1.1.1.tgz#7818258843856ae971eae4208ad7d7eb19a431b1"
@@ -4996,6 +5067,11 @@ react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
+react-native-linear-gradient@2.5.6:
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/react-native-linear-gradient/-/react-native-linear-gradient-2.5.6.tgz#96215cbc5ec7a01247a20890888aa75b834d44a0"
+  integrity sha512-HDwEaXcQIuXXCV70O+bK1rizFong3wj+5Q/jSyifKFLg0VWF95xh8XQgfzXwtq0NggL9vNjPKXa016KuFu+VFg==
+
 react-native-snap-carousel@^3.9.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/react-native-snap-carousel/-/react-native-snap-carousel-3.9.0.tgz#017793ca3f5e901ccd5a3117d79bb18ec08928a3"
@@ -5008,6 +5084,14 @@ react-native-status-bar-height@^2.4.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/react-native-status-bar-height/-/react-native-status-bar-height-2.5.0.tgz#bc0fb85230603850aab9667ee8111a62954de90c"
   integrity sha512-sYBCPYA/NapBSHkdm/IVL4ID3LLlIuLqINi2FBDyMkc2BU9pfSGOtkz9yfxoK39mYJuTrlTOQ7mManARUsYDSA==
+
+react-native-svg@9.13.6:
+  version "9.13.6"
+  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-9.13.6.tgz#5365fba2bc460054b90851e71f2a71006a5d373f"
+  integrity sha512-vjjuJhEhQCwWjqsgWyGy6/C/LIBM2REDxB40FU1PMhi8T3zQUwUHnA6M15pJKlQG8vaZyA+QnLyIVhjtujRgig==
+  dependencies:
+    css-select "^2.0.2"
+    css-tree "^1.0.0-alpha.37"
 
 react-native-tvos@0.62.2-0, "react-native@npm:react-native-tvos@0.62.2-0":
   version "0.62.2-0"
@@ -5674,7 +5758,7 @@ source-map@^0.5.0, source-map@^0.5.6:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
-source-map@^0.6.0, source-map@~0.6.1:
+source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==

--- a/ZappiOS/package.json
+++ b/ZappiOS/package.json
@@ -36,7 +36,7 @@
     "@react-native-community/viewpager": "3.3.0",
     "react": "16.11.0",
     "react-native": "0.62.2",
-    "react-native-linear-gradient": "^2.5.6",
+    "react-native-linear-gradient": "2.5.6",
     "react-native-svg": "9.13.6"
   },
   "devDependencies": {

--- a/ZappiOS/package.json
+++ b/ZappiOS/package.json
@@ -30,7 +30,7 @@
     "@applicaster/quick-brick-native-apple": "4.0.0-2",
     "@applicaster/zapp-apple": "0.8.17",
     "@applicaster/zapp-core": "0.13.3",
-    "@applicaster/zapp-react-native-default-player": "3.0.0",
+    "@applicaster/zapp-react-native-default-player": "3.1.0-beta.6",
     "@react-native-community/cli-platform-ios": "^4.7.0",
     "@react-native-community/netinfo": "^5.9.0",
     "@react-native-community/viewpager": "3.3.0",

--- a/ZappiOS/yarn.lock
+++ b/ZappiOS/yarn.lock
@@ -5948,7 +5948,7 @@ react-native-fast-image@8.1.5:
   resolved "https://registry.yarnpkg.com/react-native-fast-image/-/react-native-fast-image-8.1.5.tgz#0a6404c988dad68c98d26f91155d0a5293ba2ea5"
   integrity sha512-DoAWGLeQ2hbllummrpXH9B38OgM0TFmNYCF34F90/hdHZirqUtYHzF4QDdb/NV7ebSijHmM3mpkzct8PXtcYyg==
 
-react-native-linear-gradient@^2.5.6:
+react-native-linear-gradient@2.5.6, react-native-linear-gradient@^2.5.6:
   version "2.5.6"
   resolved "https://registry.yarnpkg.com/react-native-linear-gradient/-/react-native-linear-gradient-2.5.6.tgz#96215cbc5ec7a01247a20890888aa75b834d44a0"
   integrity sha512-HDwEaXcQIuXXCV70O+bK1rizFong3wj+5Q/jSyifKFLg0VWF95xh8XQgfzXwtq0NggL9vNjPKXa016KuFu+VFg==

--- a/ZappiOS/yarn.lock
+++ b/ZappiOS/yarn.lock
@@ -140,13 +140,13 @@
   dependencies:
     ramda "^0.27.0"
 
-"@applicaster/quick-brick-mobile-transport-controls@latest":
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/@applicaster/quick-brick-mobile-transport-controls/-/quick-brick-mobile-transport-controls-0.2.6.tgz#c5abe670cddbd521028bed359e20dc4d2714ce3d"
-  integrity sha512-qEXFTNc4fdLzNeQ6oH90TYVtreMtbX12QUqK/qsw2HCBWiAsILxgXT/kcQjzFZD5QNM9hRA/dPJ0HWSrA9lUzA==
+"@applicaster/quick-brick-mobile-transport-controls@0.3.0-beta.2":
+  version "0.3.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@applicaster/quick-brick-mobile-transport-controls/-/quick-brick-mobile-transport-controls-0.3.0-beta.2.tgz#9ba1974f601d037c5e2935cbb1afb1b2eb0fe2bc"
+  integrity sha512-Ug4CaIkB/b1tqT0ncWtHdHSuUonZKmS1t+V1/Y8+xYkEuSL7arYkXp09goKJtukQ5w3R6PLSOtw25SnGvaj69Q==
   dependencies:
     "@miblanchard/react-native-slider" "^1.2.2"
-    react-native-linear-gradient "^2.5.6"
+    react-native-linear-gradient "2.5.6"
 
 "@applicaster/quick-brick-native-apple@4.0.0-2":
   version "4.0.0-2"
@@ -355,12 +355,12 @@
     "@applicaster/zapp-react-native-bridge" "4.0.1-rc.17"
     "@applicaster/zapp-react-native-ui-components" "4.0.1-rc.17"
 
-"@applicaster/zapp-react-native-default-player@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@applicaster/zapp-react-native-default-player/-/zapp-react-native-default-player-3.0.0.tgz#ce860a1402e8629e78137f2a1cf08bc4fda07551"
-  integrity sha512-hzOZ0VyDgWlS7Bgx0dAngr9lwiyHUSCLzAuiYYjtnhcxX1jZkfJzNlsdAAcglGAChb9+BJc4VZgGEHexqXulAg==
+"@applicaster/zapp-react-native-default-player@3.1.0-beta.6":
+  version "3.1.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@applicaster/zapp-react-native-default-player/-/zapp-react-native-default-player-3.1.0-beta.6.tgz#ad6a722fa7a30d53d10719a4c00ff9d62a511b27"
+  integrity sha512-4akSK/Y0C3zPaonETqSzIQPOT1HgKEryjkwLQo9tIjNvf2HkPBQjq0KQ5P/UghECW+U5G7wA2N9mSXAUxWRGZw==
   dependencies:
-    "@applicaster/quick-brick-mobile-transport-controls" latest
+    "@applicaster/quick-brick-mobile-transport-controls" "0.3.0-beta.2"
     keymirror "^0.1.1"
 
 "@applicaster/zapp-react-native-fast-image@1.0.11":
@@ -5948,7 +5948,7 @@ react-native-fast-image@8.1.5:
   resolved "https://registry.yarnpkg.com/react-native-fast-image/-/react-native-fast-image-8.1.5.tgz#0a6404c988dad68c98d26f91155d0a5293ba2ea5"
   integrity sha512-DoAWGLeQ2hbllummrpXH9B38OgM0TFmNYCF34F90/hdHZirqUtYHzF4QDdb/NV7ebSijHmM3mpkzct8PXtcYyg==
 
-react-native-linear-gradient@2.5.6, react-native-linear-gradient@^2.5.6:
+react-native-linear-gradient@2.5.6:
   version "2.5.6"
   resolved "https://registry.yarnpkg.com/react-native-linear-gradient/-/react-native-linear-gradient-2.5.6.tgz#96215cbc5ec7a01247a20890888aa75b834d44a0"
   integrity sha512-HDwEaXcQIuXXCV70O+bK1rizFong3wj+5Q/jSyifKFLg0VWF95xh8XQgfzXwtq0NggL9vNjPKXa016KuFu+VFg==


### PR DESCRIPTION
## Description
Ticket:  https://applicaster.atlassian.net/browse/TPS-397
This PR is adding an svg and linear gradient to android TV and to auto-linking script. 

Aim of this task is to add dependencies use throughout QB app to the SDK so there is no need for the user to add a plugin in zapp.

## Known issues
This is a breaking change, we will need to release new RC.


## Affected packages

- [x] Native tvOS
- [ ] QuickBrick App set up

### Checklist

- [x] I've provided a readable title for the PR
- [x] the title of the PR follows the [conventional commits specifications](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#specification)
- [x] I've provided a detailed description
- [x] The PR is scoped to a single task/feature
- [x] I've included relevant tests (if tests are not included please provide the reason why they aren't)

### UI changes

> Check one of the following checkboxes

- [x] My PR is not introducing a UI change
- [ ] My PR is introducing UI changes and I provided all screenshots in the PR description

#### PR type

> check one of the following type and make sure all related checkboxes are checked.

- [x] My PR is a part of a new feature or a feature improvement
  - [x] I've provided a link in the description to the relevant card in the Zapp cycle feature rollout Trello board.
- [ ] My PR is a bug fix
  - [ ] I provided a link in the description to the relevant Jira ticket or provided the following in the PR description:
    - steps to reproduce a bug
    - expected result

### Having problem feeling out the checklist / Conforming to guidelines - explain why and consult Zapp tech lead / Head of product
