### PR TITLE
chore: add core dependencies

### DIFF
--- a/ZappTvOS/package.json
+++ b/ZappTvOS/package.json
@@ -31,7 +31,8 @@
     "react": "16.11.0",
     "react-native-tvos": "0.62.2-0",
     "react-native": "npm:react-native-tvos@0.62.2-0",
-    "react-native-svg": "9.13.6"
+    "react-native-svg": "9.13.6",
+    "react-native-linear-gradient": "2.5.6"
   },
   "devDependencies": {
     "@applicaster/zapplicaster-cli": "4.0.0"

--- a/ZappTvOS/yarn.lock
+++ b/ZappTvOS/yarn.lock
@@ -5067,6 +5067,11 @@ react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
+react-native-linear-gradient@2.5.6:
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/react-native-linear-gradient/-/react-native-linear-gradient-2.5.6.tgz#96215cbc5ec7a01247a20890888aa75b834d44a0"
+  integrity sha512-HDwEaXcQIuXXCV70O+bK1rizFong3wj+5Q/jSyifKFLg0VWF95xh8XQgfzXwtq0NggL9vNjPKXa016KuFu+VFg==
+
 react-native-snap-carousel@^3.9.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/react-native-snap-carousel/-/react-native-snap-carousel-3.9.0.tgz#017793ca3f5e901ccd5a3117d79bb18ec08928a3"

--- a/ZappiOS/Podfile
+++ b/ZappiOS/Podfile
@@ -31,6 +31,7 @@ def shared_pods
     pod 'ZappApple', :path => './node_modules/@applicaster/zapp-apple/apple/ZappApple.podspec'
     pod 'XrayLogger', :git => 'https://github.com/applicaster/x-ray.git', :tag => '0.0.2-alpha'
     pod 'react-native-viewpager', :path => 'node_modules/@react-native-community/viewpager/react-native-viewpager.podspec'
+    pod 'react-native-webview', :path => './node_modules/react-native-webview/react-native-webview.podspec'
     # Zaptool pods - Do not remove or change.
 
 end

--- a/ZappiOS/package.json
+++ b/ZappiOS/package.json
@@ -34,7 +34,9 @@
     "@react-native-community/viewpager": "3.3.0",
     "react": "16.11.0",
     "react-native": "0.62.2",
-    "react-native-svg": "9.13.6"
+    "react-native-svg": "9.13.6",
+    "react-native-webview": "9.1.1",
+    "react-native-linear-gradient": "2.5.6"
   },
   "devDependencies": {
     "@applicaster/zapplicaster-cli": "^4.0.1-rc.18",

--- a/ZappiOS/yarn.lock
+++ b/ZappiOS/yarn.lock
@@ -5917,6 +5917,11 @@ react-native-fast-image@8.1.5:
   resolved "https://registry.yarnpkg.com/react-native-fast-image/-/react-native-fast-image-8.1.5.tgz#0a6404c988dad68c98d26f91155d0a5293ba2ea5"
   integrity sha512-DoAWGLeQ2hbllummrpXH9B38OgM0TFmNYCF34F90/hdHZirqUtYHzF4QDdb/NV7ebSijHmM3mpkzct8PXtcYyg==
 
+react-native-linear-gradient@2.5.6:
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/react-native-linear-gradient/-/react-native-linear-gradient-2.5.6.tgz#96215cbc5ec7a01247a20890888aa75b834d44a0"
+  integrity sha512-HDwEaXcQIuXXCV70O+bK1rizFong3wj+5Q/jSyifKFLg0VWF95xh8XQgfzXwtq0NggL9vNjPKXa016KuFu+VFg==
+
 react-native-snap-carousel@^3.9.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/react-native-snap-carousel/-/react-native-snap-carousel-3.9.0.tgz#017793ca3f5e901ccd5a3117d79bb18ec08928a3"


### PR DESCRIPTION
## Description
This PR adds react-native-webview as a core dependency, as webview component is now a core plugin and relies on this.
I also added back the linear gradient module as I wasn't aware when I removed it that it had been removed form the manifest of the QB player from 3.0.1-beta.6 onwards

## Affected packages

- [ ] Native tvOS
- [ ] QuickBrick App set up

### Checklist

- [ ] I've provided a readable title for the PR
- [ ] the title of the PR follows the [conventional commits specifications](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#specification)
- [ ] I've provided a detailed description
- [ ] The PR is scoped to a single task/feature
- [ ] I've included relevant tests (if tests are not included please provide the reason why they aren't)

### UI changes

> Check one of the following checkboxes

- [ ] My PR is not introducing a UI change
- [ ] My PR is introducing UI changes and I provided all screenshots in the PR description

#### PR type

> check one of the following type and make sure all related checkboxes are checked.

- [ ] My PR is a part of a new feature or a feature improvement
  - [ ] I've provided a link in the description to the relevant card in the Zapp cycle feature rollout Trello board.
- [ ] My PR is a bug fix
  - [ ] I provided a link in the description to the relevant Jira ticket or provided the following in the PR description:
    - steps to reproduce a bug
    - expected result

### Having problem feeling out the checklist / Conforming to guidelines - explain why and consult Zapp tech lead / Head of product
