### PR TITLE
Patch RCimage in iOS 14, does not work in RN 0.62.2

### DIFF
--- a/Scripts/react-native-patch.js
+++ b/Scripts/react-native-patch.js
@@ -69,12 +69,12 @@ async function processFile(
 
 const IOS_FILES_TO_PATCH = [
   {
-    filePath: "./react-native/Libraries/Image/RCTUIImageViewAnimated.m",
+    filePath: "./Libraries/Image/RCTUIImageViewAnimated.m",
     operation: replaceStringInFile,
     args: {
-      lookUpString: "layer.contents = (__bridge id)_currentFrame.CGImage;\n  }",
+      lookUpString: "    layer.contents = (__bridge id)_currentFrame.CGImage;",
       correctString:
-        "layer.contents = (__bridge id)_currentFrame.CGImage;\n  } else { [super displayLayer:layer]; }",
+        "    layer.contents = (__bridge id)_currentFrame.CGImage; } else { [super displayLayer:layer];",
     },
   },
   {
@@ -124,6 +124,15 @@ const IOS_FILES_TO_PATCH = [
 ];
 
 const TVOS_FILES_TO_PATCH = [
+  {
+    filePath: "./Libraries/Image/RCTUIImageViewAnimated.m",
+    operation: replaceStringInFile,
+    args: {
+      lookUpString: "    layer.contents = (__bridge id)_currentFrame.CGImage;",
+      correctString:
+        "    layer.contents = (__bridge id)_currentFrame.CGImage; } else { [super displayLayer:layer];",
+    },
+  },
   {
     filePath: "./React/CoreModules/RCTDevMenu.h",
     operation: replaceStringInFile,

--- a/Scripts/react-native-patch.js
+++ b/Scripts/react-native-patch.js
@@ -21,7 +21,7 @@ function replaceStringInFile(file, { lookUpString, correctString }) {
     .map((line) =>
       line.includes(lookUpString)
         ? line.replace(lookUpString, correctString)
-        : line,
+        : line
     )
     .join(BREAK_LINE);
 }
@@ -34,12 +34,12 @@ function prepareReactPodspec(file) {
   const updatedFile = replaceStringInFile(file, args);
   const fileLines = updatedFile.toString().split(BREAK_LINE);
   const ssIndex = fileLines.findIndex((l) =>
-    l.includes("ss.tvos.exclude_files"),
+    l.includes("ss.tvos.exclude_files")
   );
   fileLines.splice(
     ssIndex + 1,
     0,
-    '\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t"React/Views/RCTWKWebView*",',
+    '\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t"React/Views/RCTWKWebView*",'
   );
 
   return fileLines.join(BREAK_LINE);
@@ -47,7 +47,7 @@ function prepareReactPodspec(file) {
 
 async function processFile(
   react_native_install_folder,
-  { filePath, operation, args },
+  { filePath, operation, args }
 ) {
   const fullFilePath = resolve(react_native_install_folder, filePath);
   console.log(`processing ${fullFilePath}`);
@@ -68,6 +68,15 @@ async function processFile(
 }
 
 const IOS_FILES_TO_PATCH = [
+  {
+    filePath: "./react-native/Libraries/Image/RCTUIImageViewAnimated.m",
+    operation: replaceStringInFile,
+    args: {
+      lookUpString: "layer.contents = (__bridge id)_currentFrame.CGImage;\n  }",
+      correctString:
+        "layer.contents = (__bridge id)_currentFrame.CGImage;\n  } else { [super displayLayer:layer]; }",
+    },
+  },
   {
     filePath: "./React/Base/RCTConvert.h",
     operation: replaceStringInFile,
@@ -186,8 +195,8 @@ async function run() {
     async (fileToPatch) =>
       await processFile(
         react_native_install_folder(platform_install_folder),
-        fileToPatch,
-      ),
+        fileToPatch
+      )
   );
 }
 


### PR DESCRIPTION
[Fix of the issue](https://stackoverflow.com/questions/62612812/all-image-fast-image-in-react-native-app-not-working-on-ios-14-beta-and-xcode-12)
Issue resolved in RN: `0.63.2`

## Description

- _fill in... (If you PR includes breaking changes please write it and make sure it was planned)_
- _if your PR is based on another branch than master, indicate it here too_

## Known issues

- _fill in this section with potential issues / limitations the reviewer(s) should know about_

## Affected packages

- [ ] Native tvOS
- [ ] QuickBrick App set up

### Checklist

- [ ] I've provided a readable title for the PR
- [ ] the title of the PR follows the [conventional commits specifications](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#specification)
- [ ] I've provided a detailed description
- [ ] The PR is scoped to a single task/feature
- [ ] I've included relevant tests (if tests are not included please provide the reason why they aren't)

### UI changes

> Check one of the following checkboxes

- [ ] My PR is not introducing a UI change
- [ ] My PR is introducing UI changes and I provided all screenshots in the PR description

#### PR type

> check one of the following type and make sure all related checkboxes are checked.

- [ ] My PR is a part of a new feature or a feature improvement
  - [ ] I've provided a link in the description to the relevant card in the Zapp cycle feature rollout Trello board.
- [ ] My PR is a bug fix
  - [ ] I provided a link in the description to the relevant Jira ticket or provided the following in the PR description:
    - steps to reproduce a bug
    - expected result

### Having problem feeling out the checklist / Conforming to guidelines - explain why and consult Zapp tech lead / Head of product
