### PR TITLE
feat: add patch to apply React-Core dependency in podspecs

### DIFF
--- a/Scripts/react-native-patch.js
+++ b/Scripts/react-native-patch.js
@@ -45,9 +45,16 @@ function prepareReactPodspec(file) {
   return fileLines.join(BREAK_LINE);
 }
 
+function addReactCoreDependency(file) {
+  return replaceStringInFile(file, {
+    lookUpString: "s.dependency 'React'",
+    correctString: "s.dependency 'React'\n  s.dependency 'React-Core'",
+  });
+}
+
 async function processFile(
   react_native_install_folder,
-  { filePath, operation, args }
+  { filePath, operation, args = {}, options = {} }
 ) {
   const fullFilePath = resolve(react_native_install_folder, filePath);
   console.log(`processing ${fullFilePath}`);
@@ -56,14 +63,23 @@ async function processFile(
   try {
     const file = await readFileAsync(fullFilePath);
     const fileContent = file.toString();
-    const updatedFile = operation(file, args);
+    let updatedFile;
+    if (fullFilePath.includes("linear-gradient")) {
+      updatedFile = operation(file, args, true);
+    } else {
+      updatedFile = operation(file, args);
+    }
 
     await writeFileAsync(fullFilePath, Buffer.from(updatedFile));
     console.log("done !\n");
     return;
   } catch (e) {
-    console.error(`couldn't process ${filePath} - ${e.message}`);
-    process.exit(1);
+    if (options.skipPatchIfFileIsMissing) {
+      console.warn(`file ${filePath} doesn't exist - skipping patch`);
+    } else {
+      console.error(`couldn't process ${filePath} - ${e.message}`);
+      process.exit(1);
+    }
   }
 }
 
@@ -188,7 +204,22 @@ const TVOS_FILES_TO_PATCH = [
         "  #if TARGET_OS_TV\n    shouldFallbackToBareTextComparison = YES;\n  #endif\n  if (shouldFallbackToBareTextComparison) {",
     },
   },
+  {
+    filePath: "../react-native-linear-gradient/BVLinearGradient.podspec",
+    operation: addReactCoreDependency,
+    options: {
+      skipPatchIfFileIsMissing: true,
+    },
+  },
+  {
+    filePath: "../react-native-blur/react-native-blur.podspec",
+    operation: addReactCoreDependency,
+    options: {
+      skipPatchIfFileIsMissing: true,
+    },
+  },
 ];
+
 async function run() {
   var platform_install_folder = process.argv.slice(2);
 

--- a/Scripts/react-native-patch.js
+++ b/Scripts/react-native-patch.js
@@ -63,12 +63,7 @@ async function processFile(
   try {
     const file = await readFileAsync(fullFilePath);
     const fileContent = file.toString();
-    let updatedFile;
-    if (fullFilePath.includes("linear-gradient")) {
-      updatedFile = operation(file, args, true);
-    } else {
-      updatedFile = operation(file, args);
-    }
+    const updatedFile = operation(file, args);
 
     await writeFileAsync(fullFilePath, Buffer.from(updatedFile));
     console.log("done !\n");


### PR DESCRIPTION
## Description

This PR adds an option to our patch script to add React-Core dependency to podspec which are missing it.
This is currently applied to react-native-linear-gradient and react-native blur, only for tvOS.

I also added a flag to skip the patch on a file if the file doesn't exist, instead of failing the entire process like it used to.

## Known issues

- _fill in this section with potential issues / limitations the reviewer(s) should know about_

## Affected packages

- [ ] Native tvOS
- [ ] QuickBrick App set up

### Checklist

- [ ] I've provided a readable title for the PR
- [ ] the title of the PR follows the [conventional commits specifications](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#specification)
- [ ] I've provided a detailed description
- [ ] The PR is scoped to a single task/feature
- [ ] I've included relevant tests (if tests are not included please provide the reason why they aren't)

### UI changes

> Check one of the following checkboxes

- [ ] My PR is not introducing a UI change
- [ ] My PR is introducing UI changes and I provided all screenshots in the PR description

#### PR type

> check one of the following type and make sure all related checkboxes are checked.

- [ ] My PR is a part of a new feature or a feature improvement
  - [ ] I've provided a link in the description to the relevant card in the Zapp cycle feature rollout Trello board.
- [ ] My PR is a bug fix
  - [ ] I provided a link in the description to the relevant Jira ticket or provided the following in the PR description:
    - steps to reproduce a bug
    - expected result

### Having problem feeling out the checklist / Conforming to guidelines - explain why and consult Zapp tech lead / Head of product
