### PR TITLE
fix: remove rotaion styles from zapptool

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 parameters:
   zapptool-version:
     type: string
-    default: "4.1.2"
+    default: "4.1.3"
   general-caching-key:
     type: string
     default: "ZappApple_Cache_1.0.8"


### PR DESCRIPTION
Not rotate styles in zapptool in format `RGBAHex`
AppleBuilder is using format `ARGBHex`
[ZPP-2977](https://applicaster.atlassian.net/browse/ZPP-2977)

## Description

[Jira Ticket](add your Jira ticket url here)

- _fill in... (If you PR includes breaking changes please write it and make sure it was planned)_
- _if your PR is based on another branch than master, indicate it here too_

## Known issues

- _fill in this section with potential issues / limitations the reviewer(s) should know about_

## Affected platform

- [ ] iOS
- [x] tvOS

### Checklist

- [x] I've provided a readable title for the PR
- [ ] the title of the PR follows the [conventional commits specifications](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#specification)
- [ ] I've provided a detailed description
- [ ] The PR is scoped to a single task/feature
- [ ] I've included relevant tests (if tests are not included please provide the reason why they aren't)

### UI changes

> Check one of the following checkboxes

- [ ] My PR is not introducing a UI change
- [ ] My PR is introducing UI changes and I provided all screenshots in the PR description

#### PR type

> check one of the following type and make sure all related checkboxes are checked.

- [ ] My PR is a part of a new feature or a feature improvement
  - [ ] I've provided a link in the description to the relevant card in the Zapp cycle feature rollout Trello board.
- [ ] My PR is a bug fix
  - [ ] I provided a link in the description to the relevant Jira ticket or provided the following in the PR description:
    - steps to reproduce a bug
    - expected result

### Having problem feeling out the checklist / Conforming to guidelines - explain why and consult Zapp tech lead / Head of product
