### PR TITLE
fix: limit app version validation to new app versions only

### DIFF
--- a/fastlane/Base/BuildType.rb
+++ b/fastlane/Base/BuildType.rb
@@ -154,7 +154,13 @@ class BuildType < BaseHelper
       latest_app_version_info = get_appstoreconnect_latest_version(options)
 
       validate_appstoreconnect_latest_version_not_pending_release(latest_app_version_info)
-      validate_version_number_higher_than_released_version(latest_app_version_info, app_version) if app_version
+
+      pp("Latest app info:")
+      pp(latest_app_version_info)
+
+      if app_version && latest_app_version_info.app_store_state == 'READY_FOR_SALE'
+        validate_version_number_higher_than_released_version(latest_app_version_info, app_version) 
+      end
     end
   end
 


### PR DESCRIPTION
limit app version validation to new app versions only and compare with store version

[Jira Ticket](add your Jira ticket url here)

- _fill in... (If you PR includes breaking changes please write it and make sure it was planned)_
- _if your PR is based on another branch than master, indicate it here too_

## Known issues

- _fill in this section with potential issues / limitations the reviewer(s) should know about_

## Affected platform

- [ ] iOS
- [ ] tvOS

### Checklist

- [ ] I've provided a readable title for the PR
- [ ] the title of the PR follows the [conventional commits specifications](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#specification)
- [ ] I've provided a detailed description
- [ ] The PR is scoped to a single task/feature
- [ ] I've included relevant tests (if tests are not included please provide the reason why they aren't)

### UI changes

> Check one of the following checkboxes

- [ ] My PR is not introducing a UI change
- [ ] My PR is introducing UI changes and I provided all screenshots in the PR description

#### PR type

> check one of the following type and make sure all related checkboxes are checked.

- [ ] My PR is a part of a new feature or a feature improvement
  - [ ] I've provided a link in the description to the relevant card in the Zapp cycle feature rollout Trello board.
- [ ] My PR is a bug fix
  - [ ] I provided a link in the description to the relevant Jira ticket or provided the following in the PR description:
    - steps to reproduce a bug
    - expected result

### Having problem feeling out the checklist / Conforming to guidelines - explain why and consult Zapp tech lead / Head of product
