### PR TITLE
chore: add netinfo on tvos

### DIFF
--- a/ZappTvOS/package.json
+++ b/ZappTvOS/package.json
@@ -42,7 +42,8 @@
     "react-native-linear-gradient": "2.5.6",
     "react-native-safe-area-context": "^3.2.0",
     "react-native-svg": "9.13.6",
-    "react-native-tvos": "0.62.2-0"
+    "react-native-tvos": "0.62.2-0",
+    "@react-native-community/netinfo": "^5.9.0"
   },
   "devDependencies": {
     "@applicaster/zapplicaster-cli": "5.0.1"

--- a/ZappTvOS/package.json
+++ b/ZappTvOS/package.json
@@ -45,6 +45,9 @@
     "react-native-tvos": "0.62.2-0",
     "@react-native-community/netinfo": "^5.9.0"
   },
+  "resolution": {
+    "react-native": "npm:react-native-tvos@0.62.2-0"
+  },
   "devDependencies": {
     "@applicaster/zapplicaster-cli": "5.0.1"
   },

--- a/ZappTvOS/yarn.lock
+++ b/ZappTvOS/yarn.lock
@@ -265,10 +265,10 @@
   resolved "https://registry.yarnpkg.com/@applicaster/zapp-analytics-plugins/-/zapp-analytics-plugins-13.0.0.tgz#efe3fdb4a7646c6b115b70bed88f5351ee6d9457"
   integrity sha512-rpSheuIBUNdF9Jf9vFIXD5aQLfYfh5nhwKRNP5odw6Oxvj+41ooi/aVEZWJXLhyKohER4MOOdf3UfuQCoXhebw==
 
-"@applicaster/zapp-apple@2.1.8":
-  version "2.1.8"
-  resolved "https://registry.yarnpkg.com/@applicaster/zapp-apple/-/zapp-apple-2.1.8.tgz#91f9da53c29fa52030bfc26f56c22a12460467b3"
-  integrity sha512-ymFN4hs6BiPGQy0pUamv39sYs5Tq9xAwfnZ6hwWNw4XPyPEQl8dXxpYg2QoWnuYQgo6HRN7qYR/q1W+s+LyqXA==
+"@applicaster/zapp-apple@2.1.10":
+  version "2.1.10"
+  resolved "https://registry.yarnpkg.com/@applicaster/zapp-apple/-/zapp-apple-2.1.10.tgz#43eca9e8131f07a47249472e3d4f63502ff5f1de"
+  integrity sha512-fYjYDfFYLypDIZ5Zan35T2TW3EcISN4kTg7tVrNX99tjC0IO6nWbMY6rvFG2tLDzRWtcIkIADYSfPd/2IwFXYw==
   dependencies:
     "@applicaster/x-ray" "0.2.0"
 

--- a/ZappiOS/yarn.lock
+++ b/ZappiOS/yarn.lock
@@ -265,10 +265,10 @@
   resolved "https://registry.yarnpkg.com/@applicaster/zapp-analytics-plugins/-/zapp-analytics-plugins-13.0.0.tgz#efe3fdb4a7646c6b115b70bed88f5351ee6d9457"
   integrity sha512-rpSheuIBUNdF9Jf9vFIXD5aQLfYfh5nhwKRNP5odw6Oxvj+41ooi/aVEZWJXLhyKohER4MOOdf3UfuQCoXhebw==
 
-"@applicaster/zapp-apple@2.1.8":
-  version "2.1.8"
-  resolved "https://registry.yarnpkg.com/@applicaster/zapp-apple/-/zapp-apple-2.1.8.tgz#91f9da53c29fa52030bfc26f56c22a12460467b3"
-  integrity sha512-ymFN4hs6BiPGQy0pUamv39sYs5Tq9xAwfnZ6hwWNw4XPyPEQl8dXxpYg2QoWnuYQgo6HRN7qYR/q1W+s+LyqXA==
+"@applicaster/zapp-apple@2.1.10":
+  version "2.1.10"
+  resolved "https://registry.yarnpkg.com/@applicaster/zapp-apple/-/zapp-apple-2.1.10.tgz#43eca9e8131f07a47249472e3d4f63502ff5f1de"
+  integrity sha512-fYjYDfFYLypDIZ5Zan35T2TW3EcISN4kTg7tVrNX99tjC0IO6nWbMY6rvFG2tLDzRWtcIkIADYSfPd/2IwFXYw==
   dependencies:
     "@applicaster/x-ray" "0.2.0"
 


### PR DESCRIPTION
## Description

This PR adds the netinfo module on tvos. this is required as it is used by quick-brick-core
it also adds resolution to the tvos package in case some dependency are trying to import react-native


## Affected platform

- [ ] iOS
- [ ] tvOS

### Checklist

- [ ] I've provided a readable title for the PR
- [ ] the title of the PR follows the [conventional commits specifications](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#specification)
- [ ] I've provided a detailed description
- [ ] The PR is scoped to a single task/feature
- [ ] I've included relevant tests (if tests are not included please provide the reason why they aren't)

### UI changes

> Check one of the following checkboxes

- [ ] My PR is not introducing a UI change
- [ ] My PR is introducing UI changes and I provided all screenshots in the PR description

#### PR type

> check one of the following type and make sure all related checkboxes are checked.

- [ ] My PR is a part of a new feature or a feature improvement
  - [ ] I've provided a link in the description to the relevant card in the Zapp cycle feature rollout Trello board.
- [ ] My PR is a bug fix
  - [ ] I provided a link in the description to the relevant Jira ticket or provided the following in the PR description:
    - steps to reproduce a bug
    - expected result

### Having problem feeling out the checklist / Conforming to guidelines - explain why and consult Zapp tech lead / Head of product
